### PR TITLE
Migrate parent feature chain to new cell on match

### DIFF
--- a/vid_sae_surface.sh
+++ b/vid_sae_surface.sh
@@ -7,7 +7,7 @@ rm sae_surface.mp4
 ffmpeg -r 24 \
  -f image2 \
  -start_number 1 \
- -i ./out/saesurf_%04d.png \
+ -i ./out/sae_surf_%04d.png \
  -vcodec libx264 \
  -crf 25 \
  -pix_fmt yuv420p \

--- a/vid_tracks.sh
+++ b/vid_tracks.sh
@@ -2,13 +2,13 @@
 
 # convert multiple png files to a video file
 # requires that libx264 and ffmpeg are installed
-rm sae_corners.mp4
+rm sae_tracks.mp4
 
 ffmpeg -r 24 \
  -f image2 \
  -start_number 1 \
- -i ./out/sae_corners_%04d.png \
+ -i ./out/sae_tracks_%04d.png \
  -vcodec libx264 \
  -crf 25 \
  -pix_fmt yuv420p \
- sae_corners.mp4
+ sae_tracks.mp4


### PR DESCRIPTION
Whenever we match a new feature to a parent feature, migrate the parent's chain of features (series of matched features) to the new chain, and remove the chain from the old cell. 

Updated tests and rendering as well. 